### PR TITLE
Add support for MacAddress

### DIFF
--- a/genieacs-sim
+++ b/genieacs-sim
@@ -53,7 +53,7 @@ const program = require("commander")
   .option("-p, --processes [count]", "Number of devices to simulate (default: 1)", parseFloat, 1)
   .option("-w, --wait [milliseconds]", "Waiting period between process spawning (default: 1000)", parseFloat, 1000)
   .option("-s, --serial [offset]", "Serial number offset (default: 0)", parseFloat, 0)
-  .option("-a, --mac-address [address]", "MAC address (default: 20:2B:C1:E0:06:65)", "20:2B:C1:E0:06:65")
+  .option("-a, --mac-address [address]", "MAC address (default: 20:2B:C1:E0:06:00)", "20:2B:C1:E0:06:00")
   .parse(process.argv);
 
 if (!/^(http|https):\/\//.test(program.acsUrl)) {
@@ -78,7 +78,7 @@ for (let i = 0; i < program.processes; ++i) {
   setTimeout(function () {
     let env = {
       "SERIAL_NUMBER": `00000${program.serial + i}`.slice(-6),
-      "MAC_ADDRESS": program.macAddress,
+      "MAC_ADDRESS": program.macAddress.slice(0, -2) + i.toString().padStart(2, '0'),
       "ACS_URL": program.acsUrl,
       "DATA_MODEL": program.dataModel,
     };

--- a/genieacs-sim
+++ b/genieacs-sim
@@ -12,6 +12,7 @@ if (!cluster.isMaster) {
   const acsUrl = process.env["ACS_URL"];
   const dataModel = process.env["DATA_MODEL"];
   const serialNumber = process.env["SERIAL_NUMBER"];
+  const macAddress = process.env["MAC_ADDRESS"];
 
   let device;
   const data = fs.readFileSync(dataModel);
@@ -34,7 +35,7 @@ if (!cluster.isMaster) {
     device = JSON.parse(data);
   }
 
-  simulator.start(device, serialNumber, acsUrl);
+  simulator.start(device, serialNumber, macAddress, acsUrl);
   return;
 }
 
@@ -52,6 +53,7 @@ const program = require("commander")
   .option("-p, --processes [count]", "Number of devices to simulate (default: 1)", parseFloat, 1)
   .option("-w, --wait [milliseconds]", "Waiting period between process spawning (default: 1000)", parseFloat, 1000)
   .option("-s, --serial [offset]", "Serial number offset (default: 0)", parseFloat, 0)
+  .option("-a, --mac-address [address]", "MAC address (default: 20:2B:C1:E0:06:65)", "20:2B:C1:E0:06:65")
   .parse(process.argv);
 
 if (!/^(http|https):\/\//.test(program.acsUrl)) {
@@ -59,27 +61,28 @@ if (!/^(http|https):\/\//.test(program.acsUrl)) {
   process.exit(1);
 }
 
-cluster.on("fork", function(worker) {
-  console.log(`Simulator ${worker.env["SERIAL_NUMBER"]} started`);
+cluster.on("fork", function (worker) {
+  console.log(`Simulator ${worker.env["SERIAL_NUMBER"]} (${worker.env["MAC_ADDRESS"]}) started`);
 });
 
-cluster.on("exit", function(worker, code, signal) {
-  console.log(`Simulator ${worker.env["SERIAL_NUMBER"]} died (${signal || code}). Restarting in 10 seconds...`)
-  setTimeout(function() {
+cluster.on("exit", function (worker, code, signal) {
+  console.log(`Simulator ${worker.env["SERIAL_NUMBER"]} (${worker.env["MAC_ADDRESS"]}) died (${signal || code}). Restarting in 10 seconds...`)
+  setTimeout(function () {
     let newWorker = cluster.fork(worker.env);
     newWorker.env = worker.env;
   }, 10000);
 });
 
 
-for (let i = 0; i < program.processes; ++ i) {
-  setTimeout(function() {
+for (let i = 0; i < program.processes; ++i) {
+  setTimeout(function () {
     let env = {
       "SERIAL_NUMBER": `00000${program.serial + i}`.slice(-6),
+      "MAC_ADDRESS": program.macAddress,
       "ACS_URL": program.acsUrl,
       "DATA_MODEL": program.dataModel,
     };
     let worker = cluster.fork(env);
     worker.env = env;
-  }, i  * program.wait)
+  }, i * program.wait)
 }

--- a/simulator.js
+++ b/simulator.js
@@ -270,6 +270,8 @@ function start(dataModel, serialNumber, macAddress, acsUrl) {
 
   if (device["InternetGatewayDevice.WANDevice.1.WANConnectionDevice.1.WANIPConnection.1.MACAddress"])
     device["InternetGatewayDevice.WANDevice.1.WANConnectionDevice.1.WANIPConnection.1.MACAddress"][1] = macAddress;
+  if (device["Device.WANDevice.1.WANConnectionDevice.1.WANIPConnection.1.MACAddress"])
+    device["Device.WANDevice.1.WANConnectionDevice.1.WANIPConnection.1.MACAddress"][1] = macAddress;
 
   let username = "";
   let password = "";


### PR DESCRIPTION
This PR intends to add an option to also edit the MacAddress.
This is useful for some usecases where the MacAddress is "king" and matters the most, also super useful to prevent to have thousands of sim devices with the exact same Mac :)
Said mac will silce the last 2 characters, starting at 00 and going up to 99 depending on number of processes.
I felt like pushing more than 100 devices in a single instance can worsen performance and felt like it's better to have multiple instances with up to 100 devices if we need to make stress tests.

**Help Example**

![image](https://github.com/user-attachments/assets/689b0ecb-0087-48af-9d40-ec6aa16a653a)

**Run Example**

![image](https://github.com/user-attachments/assets/b6fa2e6b-6c9b-4e60-89b1-d1fac01edceb)

**GenieACS**

![image](https://github.com/user-attachments/assets/9f67e3af-f32a-4273-ad42-f60b92ce2aee)

Feel free to provide feedback to better improve this feature. Even though it's small it allows for a bigger flexibility - specially under kubernetes :)